### PR TITLE
Added ISR - 30 seconds

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";

--- a/app/community/page.js
+++ b/app/community/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 import Header from "./components/Header";

--- a/app/community/page.js
+++ b/app/community/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";

--- a/app/community/post/[post]/page.js
+++ b/app/community/post/[post]/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/community/post/[post]/page.js
+++ b/app/community/post/[post]/page.js
@@ -1,3 +1,4 @@
+export const revalidate = 60
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";

--- a/app/events/[event]/page.js
+++ b/app/events/[event]/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/events/[event]/page.js
+++ b/app/events/[event]/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";

--- a/app/events/page.js
+++ b/app/events/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/events/page.js
+++ b/app/events/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";

--- a/app/page.js
+++ b/app/page.js
@@ -1,3 +1,5 @@
+export const revalidate = 60
+
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,4 @@
-export const revalidate = 60
+export const revalidate = 30
 
 import { client } from "@/sanity/lib/client";
 import { groq } from "next-sanity";


### PR DESCRIPTION
Prior versions of the website used purely SSG - Static Site Generation; This means, when the site is built/compiled, the data becomes apart of it. It only pulls data once. By adding `export const revalidate = 30` to every page that queries data from Sanity, it should be no more than 30 seconds for each page to "want" to retrieve new data from Sanity.

You can change this 30 value across all pages depending on what feels good for you. Typically, you want to balance this number between page load time and staleness of data. For example, you can set it to 0, and it will get the latest data ASAP. However, each page load might take a long time. So at 30 seconds, we give ourselves a better balance. You can change this to what works for you!

--- 

This is an implementation of **Incremental Static Regeneration**.  In a nutshell:

> Incremental Static Regeneration (ISR) allows you to create or update content on your site without redeploying.

(As mentioned, prior versions of this site required a redeployment/build process for new data) 

[Learn more in the Next.js documentation](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)

---

Questions? Ask @ritesh-kanchi / [contact me](https://riteshkanchi.com)